### PR TITLE
fix(http): don't send empty `Sec-WebSocket-Protocol` header

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -149,8 +149,8 @@ pub fn build_connect_handshake_request(
     http_request.push_str(websocket_options.origin)?;
 
     // turn sub protocol list into a CSV list
-    http_request.push_str("\r\nSec-WebSocket-Protocol: ")?;
     if let Some(sub_protocols) = websocket_options.sub_protocols {
+        http_request.push_str("\r\nSec-WebSocket-Protocol: ")?;
         for (i, sub_protocol) in sub_protocols.iter().enumerate() {
             http_request.push_str(sub_protocol)?;
             if i < (sub_protocols.len() - 1) {


### PR DESCRIPTION
In the wild some servers do not even accept request when this header is present, but empty. According to spec this header is optional too, so it should be correct and more compatible to not send it when no subprotocols are specified.